### PR TITLE
Add three possible configurations to launch and debug this Next.js application

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,20 +1,27 @@
 {
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-  "version": "0.2.0",
   "configurations": [
     {
-      "type": "node",
+      "name": "Next.js: debug full stack",
+      "type": "node-terminal",
       "request": "launch",
-      "name": "Launch Program",
-      "skipFiles": [
-        "<node_internals>/**"
-      ],
-      "program": "${workspaceFolder}/components/HockeyRinkOverlay/HockeyRinkOverlay.tsx",
-      "outFiles": [
-        "${workspaceFolder}/**/*.js"
-      ]
-    }
+      "command": "npm run dev",
+      "serverReadyAction": {
+        "pattern": "started server on .+, url: (https?://.+)",
+        "uriFormat": "%s",
+        "action": "debugWithChrome"
+      }
+    },
+    {
+      "name": "Next.js: debug server-side",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "npm run dev"
+    },
+    {
+      "name": "Next.js: debug client-side",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:3000"
+    },
   ]
 }


### PR DESCRIPTION
As a Next.js developer using VS Code, I wanted to incorporate the ability to debug:

- Server-side and client-side code in my application
- Isolated server-side code
- Isolated client-side code
